### PR TITLE
Add host property to DiscoveryResultMDNSSD

### DIFF
--- a/lib/DiscoveryResultMDNSSD.d.ts
+++ b/lib/DiscoveryResultMDNSSD.d.ts
@@ -22,4 +22,6 @@ declare class DiscoveryResultMDNSSD extends DiscoveryResult {
     name: string;
     /** The full name of the device. */
     fullname: string;
+    /** The host of the device. */
+    host: string;
 }


### PR DESCRIPTION
I believe this is missing (or at least, it is set for me with my current app).