### PR TITLE
Fixed Device.d.ts

### DIFF
--- a/lib/Device.d.ts
+++ b/lib/Device.d.ts
@@ -277,15 +277,15 @@ declare class Device extends SimpleClass {
      * This method is called when the user updates the device's name. Use this to synchronize the name to the device or bridge.
      * @param {string} name The new name
      */
-    onRenamed(name: string): void;
+    onRenamed(name: string): Promise<void>;
     /**
      * This method is called when the user deleted the device.
      */
-    onDeleted(): void;
+    onDeleted(): Promise<void>;
     /**
      * This method is called when the user adds the device, called just after pairing.
      */
-    onAdded(): void;
+    onAdded(): Promise<void>;
     /**
      * This method is called when the device is loaded, and properties such as name, capabilities and state are available.
      */


### PR DESCRIPTION
I see that all the `on` functions in Device.d.ts are being called like this on my Homey Pro (Early 2019):
```javascript
await this.onAdded()
await this.onRenamed(this[sName])
await this.onDeleted()
```
This PR fixes the return types of these methods.